### PR TITLE
Fix theme icon sync

### DIFF
--- a/script.js
+++ b/script.js
@@ -844,4 +844,8 @@ function fetchUpcoming(type = 'movie', genreId = null) {
 
 // Preserve tema
 const saved = localStorage.getItem('theme');
-if (saved) document.documentElement.setAttribute('data-theme', saved);
+if (saved) {
+  document.documentElement.setAttribute('data-theme', saved);
+  const icon = document.querySelector('.theme-toggle i');
+  if (icon) icon.className = saved === 'dark' ? 'fas fa-sun' : 'fas fa-moon';
+}


### PR DESCRIPTION
## Summary
- sync theme toggle icon with persisted theme on page load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843111cf6388322a67ee1d9d9ca1e65