### PR TITLE
Refactor menu init to avoid duplicate handlers

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@ let currentType = 'movie'; // 'movie' ou 'tv'
 let currentGenre = null;
 let currentMode = 'default'; // 'default', 'releases', 'premieres', 'upcoming'
 
-document.addEventListener('DOMContentLoaded', () => {
+function initMenu() {
   const btn = document.querySelector('.hamburger');
   const nav = document.querySelector('.main-nav');
   const overlay = document.querySelector('.nav-overlay');
@@ -67,7 +67,13 @@ document.addEventListener('DOMContentLoaded', () => {
     if (closeBtn) closeBtn.onclick = closeModal;
     if (overlay) overlay.onclick = closeModal;
   }
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initMenu);
+} else {
+  initMenu();
+}
 
 // --- NOVO: Função para buscar gêneros ---
 function fetchGenres(type = 'movie') {


### PR DESCRIPTION
## Summary
- extract DOMContentLoaded logic into a reusable `initMenu` function
- call `initMenu` based on `document.readyState` for safe execution

## Testing
- `node test_menu.js` *(verify hamburger toggle)*

------
https://chatgpt.com/codex/tasks/task_e_68432007020c8322b2a5d8bf07c3db95