### PR TITLE
Fix nav hidden toggle

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,6 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const expanded = btn.getAttribute('aria-expanded') === 'true';
     btn.setAttribute('aria-expanded', String(!expanded));
     nav.classList.toggle('show');
+    nav.hidden = expanded;
     overlay.classList.toggle('active');
     document.body.style.overflow = !expanded ? 'hidden' : '';
   }


### PR DESCRIPTION
## Summary
- keep body's scroll disabled when menu is open
- remove `hidden` from `<nav>` when showing menu and add it back when hiding

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_684316c53ad883228a0745f6a4dd3e31