### PR TITLE
Add Jest test for mobile menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 Filmes e séries mais assistidas e estréias no cinema e nos streams.
+
+## Executando os testes
+
+Instale as dependências e execute:
+
+```bash
+npm test
+```
+
+Isso roda a suíte de testes em Jest.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jsdom'
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "filmesseries",
+  "version": "1.0.0",
+  "description": "Filmes e séries mais assistidas e estréias no cinema e nos streams.",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "jsdom": "^26.1.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -16,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function toggleMenu() {
     const expanded = btn.getAttribute('aria-expanded') === 'true';
     btn.setAttribute('aria-expanded', String(!expanded));
+    nav.hidden = expanded;
     nav.classList.toggle('show');
     overlay.classList.toggle('active');
     document.body.style.overflow = !expanded ? 'hidden' : '';

--- a/tests/toggleMenu.test.js
+++ b/tests/toggleMenu.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('toggleMenu', () => {
+  beforeEach(() => {
+    const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+    document.documentElement.innerHTML = html;
+    jest.resetModules();
+    global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({ genres: [], results: [] }) }));
+    require('../script.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  });
+
+  test('hamburger click toggles nav hidden and show class', () => {
+    const button = document.querySelector('.hamburger');
+    const nav = document.querySelector('.main-nav');
+
+    // initial state
+    expect(nav.hidden).toBe(true);
+    expect(nav.classList.contains('show')).toBe(false);
+
+    // first click - show
+    button.click();
+    expect(nav.hidden).toBe(false);
+    expect(nav.classList.contains('show')).toBe(true);
+
+    // second click - hide again
+    button.click();
+    expect(nav.hidden).toBe(true);
+    expect(nav.classList.contains('show')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- initialize Node project with Jest
- toggle `hidden` attribute in menu
- add Jest config and hamburger menu test
- describe how to run tests in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68431292a8c88322a8676a65974a8ee7